### PR TITLE
Automatically adjust carousel height

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -217,13 +217,21 @@ a {
     -webkit-box-direction: normal;
     -ms-flex-direction: column;
     flex-direction: column;
-    height: 60vh;
+
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
 }
 
 .carousel>div.carouselPhoto {
     position: relative;
-    height: 90%;
     overflow: hidden;
+
+    -webkit-box-flex: 1;
+    -ms-flex-positive: 1;
+    flex-grow: 1;
 }
 
 .carousel>div.carouselPhoto>div {
@@ -254,7 +262,6 @@ a {
 
 .carousel>div.carouselCaption {
     text-align: center;
-    height: 10%;
 }
 
 /* The Modal (background) */
@@ -364,4 +371,8 @@ a {
 .nav-link {
     --bs-nav-link-hover-color: rgb(120 166 197);
     --bs-nav-link-color: rgb(60 101 129);
+}
+
+.vh-50 {
+    height: 50vh !important;
 }

--- a/index.html
+++ b/index.html
@@ -161,11 +161,11 @@
     </div>
     <div id="OurStory5" class="ourStory">
         <div class="invisible-block"></div>
-        <div class="container eventsContainer shrinkElement">
-            <div class="row col-lg-8 offset-lg-2">
+        <div class="container eventsContainer shrinkElement vh-50">
+            <div class="d-flex flex-column col-lg-8 offset-lg-2 h-100">
                 <div class="eventHeader storyHeader">Our story</div>
                 <p id="TextStory5">It has been six years since Ting-Wei and Hsiang-Chih were together. Their daily life is full of funny moments. During the Covid, they witnessed Hsiang-Chih’s super long beard, as well as the fantastic comet in 2020. Hsiang-Chih often wolfed down the snacks, but not allowing Ting-Wei to do the same thing. Hsiang-Chih would also tell Ting-Wei not to sit with crossed legs, saying that it’s not good for her knees. <br>Anyway, they seem to enjoy a lot their daily life! </p>
-                <div id="CarouselStory" class="row carousel">
+                <div id="CarouselStory" class="carousel">
                     <div class="carouselPhoto">
                         <div>
                             <img class="lazy" data-src="assets/gif/beard2.gif" src="assets/gif/beard2.gif" tw-data="在Covid期間，翔致留了超級大鬍子" en-data="Hsiang-Chih grew out his mustache/beard during lock-down in 2020">
@@ -266,11 +266,11 @@
     </div>
     <div id="Photo" class="photo">
         <div class="sticky-top-blank"></div>
-        <div class="container eventsContainer shrinkElement">
-            <div class="row col-lg-8 offset-lg-2">
+        <div class="container eventsContainer shrinkElement vh-50">
+            <div class="d-flex flex-column col-lg-8 offset-lg-2 h-100">
                 <div class="eventHeader photoHeader" id="TextPhotoHeader">Our photos</div>
                 <p id="TextPhoto">Now it is time for some real-person photos! </p>
-                <div id="CarouselPhoto" class="row carousel">
+                <div id="CarouselPhoto" class="carousel">
                     <div class="carouselPhoto">
                         <div>
                             <img class="lazy" data-src="assets/low-res/han_0.jpg" src="assets/low-res/han_0.jpg" tw-data="2022年春，約翰霍普金斯大學裡的櫻花盛開" en-data="Spring 2022, cherry blossom in Johns Hopkins University">


### PR DESCRIPTION
Instead of hard-code carousel to 60vh, use height:100% to adjust to the
height of the parent container.
Instead of 90/10% split of the photo/caption section, use flex-grow
instead.

Set the container's height to 50vh instead.