### PR TITLE
Use the first element in carousel for carousel height adjustment

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -217,13 +217,36 @@ a {
     -webkit-box-direction: normal;
     -ms-flex-direction: column;
     flex-direction: column;
-    height: 60vh;
+
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
 }
 
 .carousel>div.carouselPhoto {
     position: relative;
-    height: 90%;
     overflow: hidden;
+
+    -webkit-box-flex: 1;
+    -ms-flex-positive: 1;
+    flex-grow: 1;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: row;
+    flex-direction: row;
+    -ms-flex-wrap: nowrap;
+    flex-wrap: nowrap;
+}
+
+.carousel>div.carouselPhoto>div:first-child,
+.carousel>div.carouselPhoto>div:first-child>img {
+    visibility: hidden;
+    position: inherit;
 }
 
 .carousel>div.carouselPhoto>div {
@@ -246,7 +269,7 @@ a {
     -o-object-fit: cover;
     object-fit: cover;
     max-width: 100%;
-    max-height: 100%;
+    max-height: 60vh;
     -webkit-box-shadow: 10px 8px 20px black;
     box-shadow: 10px 8px 20px black;
     -webkit-box-reflect: below 0px linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.4));
@@ -254,7 +277,6 @@ a {
 
 .carousel>div.carouselCaption {
     text-align: center;
-    height: 10%;
 }
 
 /* The Modal (background) */
@@ -321,10 +343,6 @@ a {
 @media only screen and (max-width:768px) {
     .modal-content {
         width: 100%;
-    }
-
-    #Carousel>div {
-        width: 60%;
     }
 
     .nav {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -269,7 +269,7 @@ a {
     -o-object-fit: cover;
     object-fit: cover;
     max-width: 100%;
-    max-height: 60vh;
+    max-height: 75vh;
     -webkit-box-shadow: 10px 8px 20px black;
     box-shadow: 10px 8px 20px black;
     -webkit-box-reflect: below 0px linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.4));

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -378,9 +378,13 @@ class Carousel {
 
         config = setUndefined(config, {});
         this.element = $(element).children(".carouselPhoto");
+        // Copy the first photo for css height calculation.
+        var firstPhoto = $($(this.element).children()[0]).clone();
+        this.element.prepend(firstPhoto);
+
         this.captionElement = $(element).children(".carouselCaption");
 
-        this.currentIndex = setUndefined(config.currentIndex, 0);
+        this.currentIndex = setUndefined(config.currentIndex, 1);
         this.itemsRow = setUndefined(config.itemsRow, 5);
         this.zIndex = setUndefined(config.zIndex, true);
         this.grayscale = setUndefined(config.grayscale, true);
@@ -438,7 +442,7 @@ class Carousel {
 
     _adjustPosition(index) {
         var items = $(this.element).children();
-        if (index < 0 || Math.ceil(index) >= items.length) {
+        if (index < 1 || Math.ceil(index) >= items.length) {
             return;
         }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -446,7 +446,8 @@ class Carousel {
             return;
         }
 
-        var halfItem = Math.floor(this.itemsRow / 2);
+        var itemsRow = typeof this.itemsRow === "function" ? this.itemsRow(this) : this.itemsRow;
+        var halfItem = Math.floor(itemsRow / 2);
         var carousel = this;
         items.each(function(idx, item) {
             var idxDiff = idx - index;
@@ -470,9 +471,9 @@ class Carousel {
                 cursor = "zoom-in";
             }
 
-            var left = 50 + 100.0 / carousel.itemsRow * idxDiff;
+            var left = 50 + 100.0 / itemsRow * idxDiff;
             // Allows image overlap with each other.
-            var width = carousel.overlapFactor / carousel.itemsRow;
+            var width = carousel.overlapFactor / itemsRow;
             $(item).css({
                 "left": left + "%",
                 "transform": "translateY(0%) translateX(-50%) scale(" + targetScale + ")",
@@ -491,9 +492,20 @@ class Carousel {
     }
 }
 
+var bootstrapMdWidthBreak = 768;
 var myCarousel = [
-    new Carousel($("#CarouselPhoto"), { overlapFactor: 200 }),
-    new Carousel($("#CarouselStory"), { itemsRow: 3, overlapFactor: 200 })
+    new Carousel($("#CarouselPhoto"), {
+        itemsRow: function() {
+            return $(window).width() < bootstrapMdWidthBreak ? 3 : 5;
+        },
+        overlapFactor: 200
+    }),
+    new Carousel($("#CarouselStory"), {
+        itemsRow: function() {
+            return $(window).width() < bootstrapMdWidthBreak ? 3 : 5;
+        },
+        overlapFactor: 200
+    })
 ];
 var initialize = function() {
     $("#mandarinButton").click(function() {

--- a/index.html
+++ b/index.html
@@ -162,10 +162,10 @@
     <div id="OurStory5" class="ourStory">
         <div class="invisible-block"></div>
         <div class="container eventsContainer shrinkElement">
-            <div class="row col-lg-8 offset-lg-2">
+            <div class="d-flex flex-column col-lg-8 offset-lg-2 h-100">
                 <div class="eventHeader storyHeader">Our story</div>
                 <p id="TextStory5">It has been six years since Ting-Wei and Hsiang-Chih were together. Their daily life is full of funny moments. During the Covid, they witnessed Hsiang-Chih’s super long beard, as well as the fantastic comet in 2020. Hsiang-Chih often wolfed down the snacks, but not allowing Ting-Wei to do the same thing. Hsiang-Chih would also tell Ting-Wei not to sit with crossed legs, saying that it’s not good for her knees. <br>Anyway, they seem to enjoy a lot their daily life! </p>
-                <div id="CarouselStory" class="row carousel">
+                <div id="CarouselStory" class="carousel">
                     <div class="carouselPhoto">
                         <div>
                             <img class="lazy" data-src="assets/gif/beard2.gif" src="assets/gif/beard2.gif" tw-data="在Covid期間，翔致留了超級大鬍子" en-data="Hsiang-Chih grew out his mustache/beard during lock-down in 2020">
@@ -267,10 +267,10 @@
     <div id="Photo" class="photo">
         <div class="sticky-top-blank"></div>
         <div class="container eventsContainer shrinkElement">
-            <div class="row col-lg-8 offset-lg-2">
+            <div class="d-flex flex-column col-lg-8 offset-lg-2 h-100">
                 <div class="eventHeader photoHeader" id="TextPhotoHeader">Our photos</div>
                 <p id="TextPhoto">Now it is time for some real-person photos! </p>
-                <div id="CarouselPhoto" class="row carousel">
+                <div id="CarouselPhoto" class="carousel">
                     <div class="carouselPhoto">
                         <div>
                             <img class="lazy" data-src="assets/high-res/han_0.jpg" src="assets/low-res/han_0.jpg" tw-data="2022年春，約翰霍普金斯大學裡的櫻花盛開" en-data="Spring 2022, cherry blossom in Johns Hopkins University">


### PR DESCRIPTION
Instead of hard-code the container/carousel height, copy a hidden non-absolute
positioning photo for CSS height adjustment.

Instead of 90/10% split of the photo/caption section, use flex-grow
instead.